### PR TITLE
Pandas is an optional dependency

### DIFF
--- a/partd/__init__.py
+++ b/partd/__init__.py
@@ -10,7 +10,8 @@ from .compressed import *
 from .utils import ignoring
 with ignoring(ImportError):
     from .numpy import Numpy
-from .pandas import PandasColumns, PandasBlocks
+with ignoring(ImportError):
+    from .pandas import PandasColumns, PandasBlocks
 with ignoring(ImportError):
     from .zmq import Client, Server
 

--- a/partd/tests/test_pandas.py
+++ b/partd/tests/test_pandas.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
-pytest.importorskip('numpy')
+pytest.importorskip('pandas')
 
 import pandas as pd
 import pandas.util.testing as tm


### PR DESCRIPTION
- Fix imports in `__init__.py` to not fail when missing pandas
- Fix use of `pytest.importorskip` to check for pandas in pandas test file.