### PR TITLE
FIX: memory_usage not propagated through serialization.

### DIFF
--- a/partd/buffer.py
+++ b/partd/buffer.py
@@ -23,7 +23,7 @@ class Buffer(Interface):
     def __getstate__(self):
         return {'fast': self.fast,
                 'slow': self.slow,
-                'total_memory': self.memory_usage,
+                'memory_usage': self.memory_usage,
                 'lengths': self.lengths,
                 'available_memory': self.available_memory}
 

--- a/partd/tests/test_buffer.py
+++ b/partd/tests/test_buffer.py
@@ -42,3 +42,13 @@ def test_pickle():
             d = pickle.loads(pickle.dumps(c))
 
             assert d.get('x') == c.get('x')
+
+            pickled_attrs = ('memory_usage', 'lengths', 'available_memory')
+            for attr in pickled_attrs:
+                assert hasattr(d, attr)
+                assert getattr(d, attr) == getattr(c, attr)
+            # special case Dict and File -- some attrs do not pickle
+            assert hasattr(d, 'fast')
+            assert d.fast.data == c.fast.data
+            assert hasattr(d, 'slow')
+            assert d.slow.path == c.slow.path


### PR DESCRIPTION
Forgive me if this is completely wrong, as this is my first day trying out dask, but I think I found a spelling error that causes a `Buffer` to deserialize without a `memory_usage` attribute.

To reproduce error that brought me here:

```python
# setup
import dask.dataframe as dd
from distributed import Executor
executor = Executor('10.34.22.76:8786')
a = da.random.randint(0, 10, (10000000, 3), chunks=(1000000, 3))
df = dd.from_array(a)

# with workers running this branch of partd
In [9]: df.groupby(0).apply(np.sum, columns=[0]).compute(get=executor.get)
Out[9]:
         0        1        2
0
0        0   450718   447893
1   100011   450187   450078
2   599324  1347687  1347653
3   299088   449567   448756
4  1199156  1348902  1350645
5  1500090  1349389  1353203
6  1795686  1348248  1345022
7  2102072  1349672  1349477
8  2401512  1348814  1351384
9   901062   450345   451228

# with workers running master branch of partd
In [10]: df.groupby(0).apply(np.sum, columns=[0]).compute(get=executor.get)
distributed.utils - ERROR - 'Buffer' object has no attribute 'memory_usage'
Traceback (most recent call last):
  File "/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/distributed/utils.py", line 102, in f
    result[0] = yield gen.maybe_future(func(*args, **kwargs))
  File "/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/tornado/gen.py", line 1008, in run
    value = future.result()
  File "/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/tornado/concurrent.py", line 232, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
  File "/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/tornado/gen.py", line 1014, in run
    yielded = self.gen.throw(*exc_info)
  File "/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/distributed/executor.py", line 686, in _gather
    d['traceback'])
  File "/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/Users/dallan/Documents/Repos/dask/dask/dataframe/shuffle.py", line 255, in partition
    p.append(d)
  File "/Users/dallan/Documents/Repos/partd/partd/encode.py", line 25, in append
    self.partd.append(data, **kwargs)
  File "/Users/dallan/Documents/Repos/partd/partd/buffer.py", line 40, in append
    self.memory_usage += len(v)
AttributeError: 'Buffer' object has no attribute 'memory_usage'
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-10-e372fcb6ff97> in <module>()
----> 1 df.groupby(0).apply(np.sum, columns=[0]).compute(get=executor.get)

/Users/dallan/Documents/Repos/dask/dask/base.py in compute(self, **kwargs)
     84             Extra keywords to forward to the scheduler ``get`` function.
     85         """
---> 86         return compute(self, **kwargs)[0]
     87
     88     @classmethod

/Users/dallan/Documents/Repos/dask/dask/base.py in compute(*args, **kwargs)
    177         dsk = merge(var.dask for var in variables)
    178     keys = [var._keys() for var in variables]
--> 179     results = get(dsk, keys, **kwargs)
    180
    181     results_iter = iter(results)

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/distributed/executor.py in get(self, dsk, keys, restrictions, loose_restrictions)
   1047
   1048         try:
-> 1049             results = self.gather(futures)
   1050         except (KeyboardInterrupt, Exception) as e:
   1051             for f in futures.values():

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/distributed/executor.py in gather(self, futures, errors, maxsize)
    761             return (self.gather(f, errors=errors) for f in futures)
    762         else:
--> 763             return sync(self.loop, self._gather, futures, errors=errors)
    764
    765     @gen.coroutine

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/distributed/utils.py in sync(loop, func, *args, **kwargs)
    114         e.wait(1000000)
    115     if error[0]:
--> 116         six.reraise(type(error[0]), error[0], traceback[0])
    117     else:
    118         return result[0]

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/six.py in reraise(tp, value, tb)
    684         if value.__traceback__ is not tb:
    685             raise value.with_traceback(tb)
--> 686         raise value
    687
    688 else:

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/distributed/utils.py in f()
    100     def f():
    101         try:
--> 102             result[0] = yield gen.maybe_future(func(*args, **kwargs))
    103         except Exception as exc:
    104             logger.exception(exc)

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/tornado/gen.py in run(self)
   1006
   1007                     try:
-> 1008                         value = future.result()
   1009                     except Exception:
   1010                         self.had_exception = True

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/tornado/concurrent.py in result(self, timeout)
    230             return self._result
    231         if self._exc_info is not None:
--> 232             raise_exc_info(self._exc_info)
    233         self._check_done()
    234         return self._result

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/tornado/util.py in raise_exc_info(exc_info)

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/tornado/gen.py in run(self)
   1012
   1013                     if exc_info is not None:
-> 1014                         yielded = self.gen.throw(*exc_info)
   1015                         exc_info = None
   1016                     else:

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/distributed/executor.py in _gather(self, futures, errors)
    684                         six.reraise(type(d['exception']),
    685                                     d['exception'],
--> 686                                     d['traceback'])
    687                     if errors == 'skip':
    688                         bad_keys.add(key)

/Users/dallan/miniconda/envs/bnl/lib/python3.5/site-packages/six.py in reraise(tp, value, tb)
    683             value = tp()
    684         if value.__traceback__ is not tb:
--> 685             raise value.with_traceback(tb)
    686         raise value
    687

/Users/dallan/Documents/Repos/dask/dask/dataframe/shuffle.py in partition()
    253     d = dict((i, df.iloc[groups.groups[i]]) for i in range(npartitions)
    254                                             if i in groups.groups)
--> 255     p.append(d)
    256
    257

/Users/dallan/Documents/Repos/partd/partd/encode.py in append()
     23         data = valmap(self.encode, data)
     24         data = valmap(frame, data)
---> 25         self.partd.append(data, **kwargs)
     26
     27     def _get(self, keys, **kwargs):

/Users/dallan/Documents/Repos/partd/partd/buffer.py in append()
     38             for k, v in data.items():
     39                 self.lengths[k] += len(v)
---> 40                 self.memory_usage += len(v)
     41             self.fast.append(data, lock=False, **kwargs)
     42         finally:

AttributeError: 'Buffer' object has no attribute 'memory_usage'
```