### PR TITLE
FIX: Propagate explicitly_given_path through serialization.

### DIFF
--- a/partd/file.py
+++ b/partd/file.py
@@ -24,11 +24,13 @@ class File(Interface):
         Interface.__init__(self)
 
     def __getstate__(self):
-        return {'path': self.path}
+        return {'path': self.path,
+                '_explicitly_given_path': self._explicitly_given_path}
 
     def __setstate__(self, state):
         Interface.__setstate__(self, state)
         File.__init__(self, state['path'])
+        self._explicitly_given_path = state['_explicitly_given_path']
 
     def append(self, data, lock=True, fsync=False, **kwargs):
         if lock: self.lock.acquire()

--- a/partd/tests/test_file.py
+++ b/partd/tests/test_file.py
@@ -1,6 +1,7 @@
+import tempfile
+import pickle
 from partd.file import File
 
-import shutil
 import os
 
 
@@ -73,3 +74,15 @@ def test_del():
     with File('Foo') as p:
         p.__del__()
         assert os.path.exists(p.path)
+
+
+def test_pickle():
+    # test with and without explicit path
+    for path in (None, tempfile.mkdtemp('.partd')):
+        a = File(path)
+        a.append({'x': b'123'})
+        b = pickle.loads(pickle.dumps(a))
+
+        assert a.get('x') == b.get('x')
+        assert a.path == b.path
+        assert a._explicitly_given_path == b._explicitly_given_path


### PR DESCRIPTION
Very minor thing I noticed while working on #12: an unpickle `File` always has `_explicitly_given_path` set to `True`. It's not part of the public API, but it could be confusing to someone debugging. This PR propagates that attribute through serialization and tests.

This does make it a tiny bit more expensive to serialize a `File`. An alternative would be to set the attribute to `None` in `__setstate__` so that at least it is not incorrect.