### PR TITLE
'partd.log' is less likely to be an already-existing directory

### DIFF
--- a/partd/zmq.py
+++ b/partd/zmq.py
@@ -26,7 +26,7 @@ from .utils import ignoring
 tuple_sep = b'-|-'
 
 def log(*args):
-    with open('log', 'a') as f:
+    with open('partd.log', 'a') as f:
         print(datetime.now(), *args, file=f)
 
 


### PR DESCRIPTION
Closes #17. Happy to make this more robust (i.e. actually check for and handle the case where the log file exists and is a directory) if you prefer.