### PR TITLE
Fix pandas/numpy serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 sudo: false
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 sudo: false
 python:
-    - "2.6"
     - "2.7"
     - "3.3"
     - "3.4"
+    - "3.5"
 
 
 install:
@@ -18,9 +18,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytest numpy pip toolz pandas pyzmq
-  - pip install locket
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install blosc; fi
+  - conda install pytest locket numpy toolz pandas blosc pyzmq -c conda-forge
 
   # Install dask
   - python setup.py install

--- a/partd/tests/test_numpy.py
+++ b/partd/tests/test_numpy.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import
 
 import pytest
-pytest.importorskip('numpy')
+np = pytest.importorskip('numpy')  # noqa
 
-import numpy as np
-import os
-import shutil
 import pickle
 
-from partd.numpy import Numpy, decode
+from partd.numpy import Numpy
+
 
 def test_numpy():
     dt = np.dtype([('a', 'i4'), ('b', 'i2'), ('c', 'f8')])
@@ -43,8 +41,13 @@ def test_serialization():
         assert (q.get('x') == [1, 2, 3]).all()
 
 
-def test_object_dtype():
-    x = np.array(['Alice', 'Bob', 'Charlie'], dtype='O')
+array_of_lists = np.empty(3, dtype='O')
+array_of_lists[:] = [[1, 2], [3, 4], [5, 6]]
+
+
+@pytest.mark.parametrize('x', [np.array(['Alice', 'Bob', 'Charlie'], dtype='O'),
+                               array_of_lists])
+def test_object_dtype(x):
     with Numpy() as p:
         p.append({'x': x})
         p.append({'x': x})
@@ -59,9 +62,3 @@ def test_datetime_types():
         p.append({'x': x, 'y': y})
         assert p.get('x').dtype == x.dtype
         assert p.get('y').dtype == y.dtype
-
-
-def test_decode():
-    assert decode([]) == []
-    assert decode(np.nan) is np.nan
-    assert decode([b'a', 1]) == ['a', 1]

--- a/partd/tests/test_pandas.py
+++ b/partd/tests/test_pandas.py
@@ -82,3 +82,15 @@ def test_serialize_categoricals(ordered):
     for ind, df in [(0, frame), (1, frame.T)]:
         df2 = deserialize(serialize(df))
         tm.assert_frame_equal(df, df2)
+
+
+def test_serialize_multi_index():
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'a', 'b', 'c'],
+                       'y': [1, 2, 3, 4, 5, 6],
+                       'z': [7., 8, 9, 10, 11, 12]})
+    df = df.groupby([df.x, df.y]).sum()
+    df.index.name = 'foo'
+    df.columns.name = 'bar'
+
+    df2 = deserialize(serialize(df))
+    tm.assert_frame_equal(df, df2)


### PR DESCRIPTION
A bug was introduced in 62a4d48d, which resulted in errors when
serializing multi-indices (as well as other complex index types). This
was caused by two underlying issues:

- False assumption that all indices can be reproduced exactly as
  ``pd.Index(index.values, name=index.name)``
- Partd failing to properly serialize object arrays containing only
  collections (e.g. an array of tuples).

This PR fixes these issues, along with a few other minor fixes:

- Serialize pandas indices separately from blocks
- Properly serialize numpy arrays containing lists/tuples
- Removes unneeded `decode` function for numpy serialization (msgpack
  can do this for us)
- Some pep8 fixes