### PR TITLE
`msgpack.packb` may not have packed utf-8 compatible bytes, so don't …

### DIFF
--- a/partd/numpy.py
+++ b/partd/numpy.py
@@ -95,7 +95,7 @@ def serialize(x):
     if x.dtype == 'O':
         l = x.flatten().tolist()
         with ignoring(Exception):  # Try msgpack (faster on strings)
-            return frame(msgpack.packb(l), use_bin_type=True)
+            return frame(msgpack.packb(l, use_bin_type=True))
         return frame(pickle.dumps(l, protocol=pickle.HIGHEST_PROTOCOL))
     else:
         return x.tobytes()

--- a/partd/numpy.py
+++ b/partd/numpy.py
@@ -95,7 +95,7 @@ def serialize(x):
     if x.dtype == 'O':
         l = x.flatten().tolist()
         with ignoring(Exception):  # Try msgpack (faster on strings)
-            return frame(msgpack.packb(l))
+            return frame(msgpack.packb(l), use_bin_type=True)
         return frame(pickle.dumps(l, protocol=pickle.HIGHEST_PROTOCOL))
     else:
         return x.tobytes()
@@ -107,10 +107,7 @@ def deserialize(bytes, dtype, copy=False):
             blocks = [msgpack.unpackb(f, encoding='utf-8')
                       for f in framesplit(bytes)]
         except Exception:
-            try:
-                blocks = [msgpack.unpackb(f) for f in framesplit(bytes)]
-            except Exception:
-                blocks = [pickle.loads(f) for f in framesplit(bytes)]
+            blocks = [pickle.loads(f) for f in framesplit(bytes)]
 
         result = np.empty(sum(map(len, blocks)), dtype='O')
         i = 0

--- a/partd/numpy.py
+++ b/partd/numpy.py
@@ -104,9 +104,13 @@ def serialize(x):
 def deserialize(bytes, dtype, copy=False):
     if dtype == 'O':
         try:
-            blocks = [msgpack.unpackb(f) for f in framesplit(bytes)]
+            blocks = [msgpack.unpackb(f, encoding='utf-8')
+                      for f in framesplit(bytes)]
         except Exception:
-            blocks = [pickle.loads(f) for f in framesplit(bytes)]
+            try:
+                blocks = [msgpack.unpackb(f) for f in framesplit(bytes)]
+            except Exception:
+                blocks = [pickle.loads(f) for f in framesplit(bytes)]
 
         result = np.empty(sum(map(len, blocks)), dtype='O')
         i = 0

--- a/partd/numpy.py
+++ b/partd/numpy.py
@@ -104,9 +104,8 @@ def serialize(x):
 def deserialize(bytes, dtype, copy=False):
     if dtype == 'O':
         try:
-            blocks = [msgpack.unpackb(f, encoding='utf-8')
-                      for f in framesplit(bytes)]
-        except:
+            blocks = [msgpack.unpackb(f) for f in framesplit(bytes)]
+        except Exception:
             blocks = [pickle.loads(f) for f in framesplit(bytes)]
 
         result = np.empty(sum(map(len, blocks)), dtype='O')

--- a/partd/tests/test_numpy.py
+++ b/partd/tests/test_numpy.py
@@ -5,6 +5,7 @@ np = pytest.importorskip('numpy')  # noqa
 
 import pickle
 
+import partd
 from partd.numpy import Numpy
 
 
@@ -62,3 +63,10 @@ def test_datetime_types():
         p.append({'x': x, 'y': y})
         assert p.get('x').dtype == x.dtype
         assert p.get('y').dtype == y.dtype
+
+
+def test_non_utf8_bytes():
+    a = np.array([b'\xc3\x28', b'\xa0\xa1', b'\xe2\x28\xa1', b'\xe2\x82\x28',
+                  b'\xf0\x28\x8c\xbc'], dtype='O')
+    s = partd.numpy.serialize(a)
+    assert (partd.numpy.deserialize(s, 'O') == a).all()


### PR DESCRIPTION
…assume so in `msgpack.unpackb'.

To reproduce the error, use partd on a numpy array that contains non-utf8 bytes.

It would be great to add a regression test for this.  I'll try to add one soon.  First, let's see if it breaks any other tests.