### PR TITLE
Remove unreachable code and undefined name 'seq'

### DIFF
--- a/partd/utils.py
+++ b/partd/utils.py
@@ -105,7 +105,6 @@ def nested_get(ind, coll, lazy=False):
             return (nested_get(i, coll, lazy=lazy) for i in ind)
         else:
             return [nested_get(i, coll, lazy=lazy) for i in ind]
-        return seq
     else:
         return coll[ind]
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/dask/partd on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./partd/utils.py:108:16: F821 undefined name 'seq'
        return seq
               ^
1     F821 undefined name 'seq'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree