### PR TITLE
Make partd work when snappy (not python-snappy) is installed

### DIFF
--- a/partd/compressed.py
+++ b/partd/compressed.py
@@ -9,7 +9,9 @@ def bytes_concat(L):
     return b''.join(L)
 
 
-with ignoring(ImportError):
+with ignoring(ImportError, AttributeError):
+    # In case snappy is not installed, or another package called snappy that does not implement compress / decompress.
+    # For example, SnapPy (https://pypi.org/project/snappy/)
     import snappy
     Snappy = partial(Encode,
                      snappy.compress,


### PR DESCRIPTION
Like with [this issue in dask](https://github.com/dask/dask/issues/4907), running:
```
python -m venv partd-snappy
cd partd-snappy
source bin/activate
pip install partd
pip install snappy
python
>>> import partd
```
results in an AttributeError. This is because `pip install snappy` installs the package [SnapPy](https://pypi.org/project/snappy/) but partd is expecting snappy to refer to the ["python-snappy" package](http://google.github.io/snappy/) (which also installs to the python package `snappy` but must be done via `pip install python-snappy`).

This pull request means that if the installed `snappy` does not implement compress / decompress then it is ignored.

