### PR TITLE
Pandas 1.3.0 compatibility

### DIFF
--- a/partd/compatibility.py
+++ b/partd/compatibility.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+from distutils.version import LooseVersion
 import sys
+
+import pandas as pd
 
 if sys.version_info[0] == 3:
     from io import StringIO
@@ -12,3 +15,5 @@ if sys.version_info[0] == 2:
     unicode = unicode
     import cPickle as pickle
     from Queue import Queue, Empty
+
+PANDAS_VERSION = LooseVersion(pd.__version__)

--- a/partd/compatibility.py
+++ b/partd/compatibility.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 
-from distutils.version import LooseVersion
 import sys
-
-import pandas as pd
 
 if sys.version_info[0] == 3:
     from io import StringIO
@@ -16,4 +13,3 @@ if sys.version_info[0] == 2:
     import cPickle as pickle
     from Queue import Queue, Empty
 
-PANDAS_VERSION = LooseVersion(pd.__version__)

--- a/partd/pandas.py
+++ b/partd/pandas.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from distutils.version import LooseVersion
 from functools import partial
 
 import numpy as np
@@ -13,8 +12,6 @@ from .compatibility import pickle
 from .encode import Encode
 from .utils import extend, framesplit, frame
 
-PANDAS_VERSION = LooseVersion(pd.__version__)
-
 try:
     # pandas >= 0.24.0
     from pandas.api.types import is_extension_array_dtype
@@ -22,7 +19,7 @@ except ImportError:
     def is_extension_array_dtype(dtype):
         return False
 
-if PANDAS_VERSION >= "1.3.0":
+try:
     # Some `ExtensionArray`s can have a `.dtype` which is not a `ExtensionDtype`
     # (e.g. they can be backed by a NumPy dtype). For these cases we check
     # whether the instance is a `ExtensionArray`.
@@ -30,7 +27,7 @@ if PANDAS_VERSION >= "1.3.0":
     from pandas.api.extensions import ExtensionArray
     def is_extension_array(x):
         return isinstance(x, ExtensionArray)
-else:
+except ImportError:
     def is_extension_array(x):
         return False
 

--- a/partd/pandas.py
+++ b/partd/pandas.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from distutils.version import LooseVersion
 from functools import partial
 
 import numpy as np
@@ -8,10 +9,11 @@ from pandas.core.internals import create_block_manager_from_blocks, make_block
 
 from . import numpy as pnp
 from .core import Interface
-from .compatibility import pickle, PANDAS_VERSION
+from .compatibility import pickle
 from .encode import Encode
 from .utils import extend, framesplit, frame
 
+PANDAS_VERSION = LooseVersion(pd.__version__)
 
 try:
     # pandas >= 0.24.0


### PR DESCRIPTION
This PR adds support for `pandas` 1.3.0. cc @jorisvandenbossche if you get a chance to take a look

Closes https://github.com/dask/partd/issues/48, xref https://github.com/dask/dask/issues/7507