### PR TITLE
Avoid `pandas` testing deprecation warning

### DIFF
--- a/partd/tests/test_pandas.py
+++ b/partd/tests/test_pandas.py
@@ -3,7 +3,7 @@ pytest.importorskip('pandas')  # noqa
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
+import pandas.testing as tm
 import os
 
 from partd.pandas import PandasColumns, PandasBlocks, serialize, deserialize


### PR DESCRIPTION
This avoid the following warning

```python
partd/tests/test_pandas.py:6
  /Users/james/projects/dask/partd/partd/tests/test_pandas.py:6: FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
    import pandas.util.testing as tm
```

when running the test suite 

xref https://github.com/dask/partd/issues/58