### PR TITLE
`DataFrame._data` deprecation in `pandas`

### DIFF
--- a/partd/pandas.py
+++ b/partd/pandas.py
@@ -183,7 +183,7 @@ def serialize(df):
     headers = [col_header, ind_header]
     bytes = [col_bytes, ind_bytes]
 
-    for block in df._data.blocks:
+    for block in df._mgr.blocks:
         h, b = block_to_header_bytes(block)
         headers.append(h)
         bytes.append(b)


### PR DESCRIPTION
`._data` has been deprecated upstream in `pandas` (xref https://github.com/pandas-dev/pandas/pull/52003). This PR handles that deprecation here. I've confirmed locally that tests pass (without the deprecation warning) when using the latest nightly `pandas` wheel. 

Similar to https://github.com/dask/dask/pull/10081

cc @j-bennet 