### PR TITLE
Avoid deprecated `is_datetime64tz_dtype` from `pandas`

### DIFF
--- a/partd/pandas.py
+++ b/partd/pandas.py
@@ -129,16 +129,10 @@ def index_from_header_bytes(header, bytes):
 
 def block_to_header_bytes(block):
     values = block.values
-    try:
-        # pandas >= 0.19
-        from pandas.api.types import is_datetime64tz_dtype
-    except ImportError:
-        from pandas.core.common import is_datetime64tz_dtype
-
     if isinstance(values, pd.Categorical):
         extension = ('categorical_type', (values.ordered, values.categories))
         values = values.codes
-    elif is_datetime64tz_dtype(block):
+    elif isinstance(block, pd.DatetimeTZDtype):
         extension = ('datetime64_tz_type', (block.values.tzinfo,))
         values = values.view('i8')
     elif is_extension_array_dtype(block.dtype) or is_extension_array(values):


### PR DESCRIPTION
Currently the test suite gives

```
partd/tests/test_pandas.py: 17 warnings
  /Users/james/projects/dask/partd/partd/pandas.py:141: FutureWarning: is_datetime64tz_dtype is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.DatetimeTZDtype)` instead.
    elif is_datetime64tz_dtype(block):
```

when run against the latest nightly `pandas` wheel due to `is_datetime64tz_dtype` being deprecated upstream. It's now recommended to just do a `isinstance(..., pd.DatetimeTZDtype)` check instead

xref https://github.com/pandas-dev/pandas/pull/52607

cc @j-bennet @phofl 

