### PR TITLE
Run doctests again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: |
-          set -ex
-          if [ $PYTHON_VERSION == "3.7" ]; then
-            pytest partd --doctest-modules --verbose
-          else
-            pytest partd --verbose
-          fi
+        run: pytest partd --doctest-modules --verbose
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Initially I was going to update to `$PYTHON_VERSION == "3.9"` but it looks like doctests pass on all Python builds, so let's just simplify and always run them 

cc @phofl 